### PR TITLE
CDPD-76086:Zeppelin CSD build failure

### DIFF
--- a/ZEPPELIN/pom.xml
+++ b/ZEPPELIN/pom.xml
@@ -6,11 +6,12 @@
   <parent>
     <groupId>com.cloudera</groupId>
     <artifactId>csd</artifactId>
-    <version>7.13.1</version>
+    <version>5.14.0</version>
   </parent>
 
   <groupId>com.cloudera.csd</groupId>
   <artifactId>ZEPPELIN</artifactId>
+  <version>7.3.1</version>
   <name>Zeppelin CSD for CDH 7.3.1+</name>
   <packaging>pom</packaging>
 
@@ -42,6 +43,7 @@
       <plugin>
         <groupId>com.cloudera.enterprise</groupId>
         <artifactId>schema-validator-maven-plugin</artifactId>
+        <version>7.6.0</version>
         <executions>
           <execution>
             <id>validate-schema</id>


### PR DESCRIPTION
**What is this PR for?**
This PR fixes the error raised during the newly added Zeppelin CSD build. 
Refer to the below ticket for more information.

**What is the Jira issue?**
[CDPD-76086](https://jira.cloudera.com/browse/CDPD-76086) (Zeppelin CSD build failure)

**How to replicate:**
1. Clone cm_csds repo.
2. Goto cm_csds:
3. Build the code using Maven:
$mvn clean build -U
4. See the error as below:
`[ERROR] ==> Unrecognized field "svgIcon". Recognized fields are "[_gateway, commands, _parameters,...
`

**Questions:**
_Are there breaking changes for older versions?_  No
_Does this need documentation?_  No

**How pre-commit build is tested?**
There is no pre-commit build for this repository. So, it is tested locally with the below configuration:
_Pre requisite:_
MVN: 3.8.8
Java: 1.8

_Maven build:_
```
$ mvn clean install -U
...
...
[INFO] --- maven-assembly-plugin:2.2-beta-5:single (make-assembly) @ ZEPPELIN ---
[INFO] Reading assembly descriptor: assembly.xml
[INFO] Building jar: /Users/sarwar.ghulam/github-workspace-cloudera/cm_csds/ZEPPELIN/target/ZEPPELIN-7.3.1.jar
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ ZEPPELIN ---
[INFO] Installing /Users/sarwar.ghulam/github-workspace-cloudera/cm_csds/ZEPPELIN/pom.xml to /Users/sarwar.ghulam/.m2/repository/com/cloudera/csd/ZEPPELIN/7.3.1/ZEPPELIN-7.3.1.pom
[INFO] Installing /Users/sarwar.ghulam/github-workspace-cloudera/cm_csds/ZEPPELIN/target/ZEPPELIN-7.3.1.jar to /Users/sarwar.ghulam/.m2/repository/com/cloudera/csd/ZEPPELIN/7.3.1/ZEPPELIN-7.3.1.jar
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] The Enterprise CSDs 5.14.0 ......................... SUCCESS [ 57.561 s]
[INFO] The Accumulo CSD 5.14.0 ............................ SUCCESS [04:26 min]
[INFO] The Accumulo 1.6 CSD 5.14.0 ........................ SUCCESS [  1.717 s]
[INFO] The Echo Service CSD 5.14.0 ........................ SUCCESS [  0.937 s]
[INFO] Kafka CSD 5.14.0 ................................... SUCCESS [05:19 min]
[INFO] The Cloudera Navigator Key Trustee CSD 5.14.0 ...... SUCCESS [  1.151 s]
[INFO] The Hadoop Key Management Server CSD 5.14.0 ........ SUCCESS [  0.941 s]
[INFO] The Spark CSD 5.14.0 ............................... SUCCESS [  1.106 s]
[INFO] The Spark on YARN CSD 5.14.0 ....................... SUCCESS [  1.289 s]
[INFO] The Spark on YARN 53 CSD 5.14.0 .................... SUCCESS [  0.874 s]
[INFO] The Spark on YARN 54 CSD 5.14.0 .................... SUCCESS [  1.129 s]
[INFO] The Spark on YARN 5.10 CSD 5.14.0 .................. SUCCESS [  1.045 s]
[INFO] The Sqoop Client CSD 5.14.0 ........................ SUCCESS [  0.745 s]
[INFO] Zeppelin CSD for CDH 7.3.1+ 7.3.1 .................. SUCCESS [06:14 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17:09 min
[INFO] Finished at: 2024-11-18T10:24:46+05:30
[INFO] ------------------------------------------------------------------------
```


**How should this be tested?**
Build should be successful.